### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "harmony-collections",
+  "main": "harmony-collections.js",
+  "version": "0.3.7",
+  "homepage": "http://benvie.github.com/harmony-collections",
+  "authors": ["Brandon Benvie <http://bbenvie.com>"],
+  "description": "Shim to provide Map, Set, and WeakMap if they're not available, with non-leaky O(1) lookup WeakMaps",
+  "moduleType": ["node"],
+  "keywords": ["harmony", "collection", "weakmap", "map", "set", "ecmascript", "es6", "shim", "garbage collection", "gc"],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hey, I would like to use your library in my web application. My build process relies on [main-bower-files](https://github.com/ck86/main-bower-files) to find external assets. I would like to use your library, but without the bower.json it would be much less convenient. Would you consider adding a bower.json that uses the 'main' property? I have added this bower.json and filled in all the values correctly. I tested it, and it works.